### PR TITLE
kinder

### DIFF
--- a/src/app/_components/theme.tsx
+++ b/src/app/_components/theme.tsx
@@ -46,7 +46,7 @@ export type Theme = ThemeFill | undefined | null;
 
 export function useThemeToFill() {
   //theme may be undefined, so need to properly handle both here. The decision is to set the icon to be invisible
-  const { theme: nextTheme } = useTheme();
+  const { resolvedTheme: nextTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {

--- a/src/app/_components/three/Blob.tsx
+++ b/src/app/_components/three/Blob.tsx
@@ -2,13 +2,6 @@
 
 import { useRef, useMemo, useEffect } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
-import {
-  Bloom,
-  SelectiveBloom,
-  Selection,
-  EffectComposer,
-  TiltShift2,
-} from "@react-three/postprocessing";
 import * as THREE from "three";
 
 export default function Blob() {
@@ -230,13 +223,13 @@ export default function Blob() {
       float n3 = snoise(vec3(pos.z * scale, pos.x * scale, t * speed + 200.0)) * 0.5 + 0.5;
 
       vec3 color1 = vec3(1.0, 0.2, 0.2); // Red
-      vec3 color2 = vec3(0.2, 1.0, 0.2); // Green
+      vec3 color2 = vec3(0.5, 0.0, 0.5); // Purple
       vec3 color3 = vec3(0.2, 0.2, 1.0); // Blue
-      vec3 color5 = vec3(0.0, 0.0, 0.0); // Magenta
+      vec3 color5 = vec3(0.0, 0.0, 0.0); // Black
 
       vec3 finalColor = mix(color1, color2, n1);
       finalColor = mix(finalColor, color3, n2);
-      finalColor = mix(finalColor, color5, snoise(pos * 0.2 + t * 0.1) * 0.5 + 0.5);
+      finalColor = mix(finalColor, color5, snoise(pos * 0.2 + t * 0.1) * 0.1 + 0.5);
 
       return finalColor;
     }

--- a/src/app/_components/three/Scene.tsx
+++ b/src/app/_components/three/Scene.tsx
@@ -40,15 +40,6 @@ function MaskedScene() {
   return (
     <group>
       <Blob />
-      <mesh position={[0, 0, 1]}>
-        <planeGeometry args={[1000, 1000]} />
-        <meshStandardMaterial
-          attach="material"
-          transparent
-          color={new THREE.Color().setHex(0x000000)}
-          opacity={0.1}
-        />
-      </mesh>
 
       <Text
         position={[0, 0, 1.5]}

--- a/src/app/_components/three/Scene.tsx
+++ b/src/app/_components/three/Scene.tsx
@@ -49,7 +49,7 @@ function MaskedScene() {
         lineHeight={0.75}
         font={"/fonts/geist_black.ttf"}
       >
-        There has to be a better way
+        There has to be a kinder way
         <Html
           className="custom-selection"
           style={{
@@ -61,7 +61,7 @@ function MaskedScene() {
           }}
           transform={true}
         >
-          There has to be a better way
+          There has to be a kinder way
         </Html>
         <MeshTransmissionMaterial
           background={new THREE.Color().setHex(0xffffff)}


### PR DESCRIPTION
- broken navbar
- cleaned up imports and actual navbar now
- scene is set up
- transparent sort
- fixes ts issues
- icon respects sys color scheme (doesn't matter what chrome is set to)
- this is pretty
- getting somewhere
- just need to fix logo
- navbar in main layout... nice
- better
- bug clean up, logo should work and shouldn't freeze on resize
- should clean up shader issues
- cleans up dark mode, cleans up github link
- cleans up highlight on windows
- clean up
- kinder
